### PR TITLE
activitymap.py: "Cc:" in a commit is not a real interaction

### DIFF
--- a/crowdgit/activitymap.py
+++ b/crowdgit/activitymap.py
@@ -93,7 +93,6 @@ ActivityMap = {
 		'caught-by':                              ['Reported-by'],
 		'cause-discovered-by':                    ['Reported-by'],
 		'cautiously-acked-by':                    ['Reviewed-by'],
-		'cc':                                     ['Informed-by'],
 		'celebrated-by':                          ['Reviewed-by'],
 		'changelog-cribbed-from':                 ['Influenced-by'],
 		'changelog-heavily-inspired-by':          ['Influenced-by'],


### PR DESCRIPTION
Don't count "Cc:" in the body of a commit as actually doing anything as it is just added by developers to notify people, they don't do any work on their end.

