### PR TITLE
activitymap: commits are not co-author

### DIFF
--- a/crowdgit/activitymap.py
+++ b/crowdgit/activitymap.py
@@ -108,7 +108,7 @@ ActivityMap = {
 		'co-developed-by':                        ['Co-authored-by'],
 		'co-developed-with':                      ['Co-authored-by'],
 		'committed':                              ['Committed-by'],
-		'committed-by':                           ['Co-authored-by', 'Committed-by'],
+		'committed-by':                           ['Committed-by'],
 		'compile-tested-by':                      ['Tested-by'],
 		'compiled-by':                            ['Tested-by'],
 		'compiled-tested-by':                     ['Tested-by'],


### PR DESCRIPTION
When commiting a change, the committer is not a co-author of the commit. So remove that tag from activitymap.py so that things are not tracked improperly.

# Changes proposed ✍️

### What
copilot:summary
​
copilot:poem

### Why


### How
copilot:walkthrough

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
