### PR TITLE
activitymap.py: "To:" in a commit is not a real interaction

### DIFF
--- a/crowdgit/activitymap.py
+++ b/crowdgit/activitymap.py
@@ -342,7 +342,6 @@ ActivityMap = {
 		'tested-by':                                      ['Tested-by'],
 		'tested-off':                                     ['Tested-by'],
 		'thanks-to':                                      ['Influenced-by', 'Informed-by'],
-		'to':                                             ['Informed-by'],
 		'tracked-by':                                     ['Tested-by'],
 		'tracked-down-by':                                ['Tested-by'],
 		'was-acked-by':                                   ['Reviewed-by'],


### PR DESCRIPTION
Don't count "To:" in the body of a commit as actually doing anything as it is just added by developers to notify people, they don't do any work on their end.

It might also end up sucking in mailing list aliases, which you don't want to track anywhere as they are not "real".
