### PR TITLE
Commit time is not the same time as the change was created

### DIFF
--- a/crowdgit/activity.py
+++ b/crowdgit/activity.py
@@ -250,7 +250,12 @@ def prepare_crowd_activities(
         source_id: str,
         source_parent_id: str = '',
     ) -> Dict:
-        dt = datetime.fromisoformat(commit['datetime'])
+        # if this is an "author" activity, the source_parent_id is ''
+        if source_parent_id == '':
+            timestamp = commit['author_datetime']
+        else
+            timestamp = commit['committer_datetime']
+        dt = datetime.fromisoformat(timestamp)
 
         # Check if username or displayName is None, an empty string, or not an actual name
         if not member["username"]:
@@ -260,7 +265,7 @@ def prepare_crowd_activities(
 
         return {
             'type': activity_type,
-            'timestamp': commit['datetime'],
+            'timestamp': timestamp,
             'sourceId': source_id,
             'sourceParentId': source_parent_id,
             'platform': 'git',

--- a/crowdgit/repo.py
+++ b/crowdgit/repo.py
@@ -199,7 +199,7 @@ def get_commits(
         repo_path,
         'log',
         commit_range,
-        f'--pretty=format:%H%n%cI%n%an%n%ae%n%cn%n%ce%n%P%n%d%n%B%n{splitter}',
+        f'--pretty=format:%H%n%aI%n%an%n%ae%n%cI%cn%n%ce%n%P%n%d%n%B%n{splitter}',
     ]
 
     if since:
@@ -247,14 +247,15 @@ def get_commits(
             continue
 
         commit_hash = commit_lines[0]
-        commit_datetime = commit_lines[1]
+        author_datetime = commit_lines[1]
         author_name = commit_lines[2]
         author_email = commit_lines[3]
-        committer_name = commit_lines[4]
-        committer_email = commit_lines[5]
-        parent_hashes = commit_lines[6].split()
-        ref_names = commit_lines[7].strip()
-        commit_message = commit_lines[8:]
+        commit_datetime = commit_lines[4]
+        committer_name = commit_lines[5]
+        committer_email = commit_lines[6]
+        parent_hashes = commit_lines[7].split()
+        ref_names = commit_lines[8].strip()
+        commit_message = commit_lines[9:]
 
         if not (is_valid_commit_hash(commit_hash) and is_valid_datetime(commit_datetime)):
             logger.error(
@@ -272,9 +273,10 @@ def get_commits(
         commits.append(
             {
                 'hash': commit_hash,
-                'datetime': commit_datetime,
+                'author_datetime': author_datetime,
                 'author_name': author_name,
                 'author_email': author_email,
+                'committer_datetime': commit_datetime,
                 'committer_name': committer_name,
                 'committer_email': committer_email,
                 'is_main_branch': is_main_branch,


### PR DESCRIPTION
Split out the commit time and author time as they are different, and can be quite noticeable for projects that work on email submissions, and enter them into the database properly.

Note, this is TOTALLY UNTESTED and might not even compile, but I think you can get the
general gist of what needs to happen here.  Authorship time is different than the time
the commit was made for many projects that deal with changes through email or cherry-pick
changes from other branches.

I used the "hack" of the function not having a source_parent_id to determine if this is an author
commit or a "normal" commit, so perhaps you don't want to do that and be more explicit?

If so, I can change it.

Also, as we have no idea when the signed-off-by or other activities were added, we just default
to commit date for them, as that's the "safest" to use here.