### PR TITLE
fix: use the correct column name in software value database table constraint

### DIFF
--- a/software-value/db.sql
+++ b/software-value/db.sql
@@ -21,5 +21,5 @@ CREATE TABLE IF NOT EXISTS language_stats (
     count INTEGER NOT NULL,
     weighted_complexity INTEGER NOT NULL,
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT unique_project_language UNIQUE (repo_url, name)
+    CONSTRAINT unique_project_language UNIQUE (repo_url, language_name)
 );


### PR DESCRIPTION
Context: software value tool.

In `db.sql`, in the `language_stats` table DSL, after renaming the `name` column to `language_name`, the constraint was not updated to reflect this. This PR fixes it.