### PR TITLE
fix: updatedAt in maintainersInternal

### DIFF
--- a/crowdgit/cm_maintainers_data/process_maintainers.py
+++ b/crowdgit/cm_maintainers_data/process_maintainers.py
@@ -66,7 +66,8 @@ async def compare_and_update_maintainers(
                 await execute(
                     """
                     UPDATE "maintainersInternal"
-                    SET "endDate" = $1
+                    SET "endDate" = $1,
+                    "updatedAt" = NOW()
                     WHERE "repoId" = $2 AND "identityId" = $3 AND role = $4
                     """,
                     (
@@ -98,7 +99,8 @@ async def compare_and_update_maintainers(
             await execute(
                 """
                 UPDATE "maintainersInternal"
-                SET "endDate" = $1
+                SET "endDate" = $1,
+                "updatedAt" = NOW()
                 WHERE "repoId" = $2 AND "identityId" = $3 AND role = $4
                 """,
                 (


### PR DESCRIPTION
# Changes proposed ✍️

Update "updatedAt" to now() whenever we update a row in "maintainersInternal" table.
This is particularly important, because this table is being synced into Tinybird, and Sequin relies on the "updatedAt" column changes to get the latest data.

## Checklist ✅
- [x] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
