### PR TITLE
fix: disable repo cloning for now

### DIFF
--- a/crowdgit/repo.py
+++ b/crowdgit/repo.py
@@ -500,6 +500,8 @@ def get_new_commits(remote: str, repos_dir: str = REPOS_DIR, verbose: bool = Fal
     if not os.path.exists(repo_path):
         # Clone the repo if it doesn't exist
         logger.info("Repo %s not existing locally", repo_path)
+        logger.warning(f"Skipping repository cloning for {remote}, repo_path: {repo_path}, repos_dir: {repos_dir}")
+        return [] # TODO: remove this once re-cloning issue is fixed
         result = clone_repo(remote, repos_dir)
         if result == 1:
             return []


### PR DESCRIPTION
# Changes proposed ✍️
 Temporary disable of repository cloning until re-cloning issue is figured out/solved
### What
copilot:summary
​
copilot:poem

### Why


### How
copilot:walkthrough

## Checklist ✅
- [ ] Label appropriately with `Feature`, `Improvement`, or `Bug`.
- [ ] Add screehshots to the PR description for relevant FE changes
- [ ] New backend functionality has been unit-tested.
- [ ] API documentation has been updated (if necessary) (see [docs on API documentation](https://docs.crowd.dev/docs/updating-api-documentation)).
- [ ] [Quality standards](https://github.com/CrowdDotDev/crowd-github-test-public/blob/main/CONTRIBUTING.md#quality-standards) are met.
